### PR TITLE
Django 1.10 support

### DIFF
--- a/sphinxql/configuration/configurators.py
+++ b/sphinxql/configuration/configurators.py
@@ -113,8 +113,7 @@ def _build_query(index, query, vendor):
 
         # Add the aggregates to the query
         for (alias, aggregate_expr) in dict_values.items():
-            obj.query.add_aggregate(aggregate_expr, query.model, alias,
-                                    is_summary=False)
+            obj.query.add_annotation(aggregate_expr, alias, is_summary=False)
 
         return obj
 


### PR DESCRIPTION
Use `add_annotation` instead of `add_aggregate`. This will also fix deprecation warnings for Django 1.9.